### PR TITLE
alter the zdb.Writer struct to prevent undefined behaviour

### DIFF
--- a/src/commands/connection.zig
+++ b/src/commands/connection.zig
@@ -19,7 +19,7 @@ pub fn echo(client: *Client, args: []const Value) !void {
 // QUIT command implementation
 pub fn quit(client: *Client, args: []const Value) !void {
     _ = args; // Unused parameter
-    _ = try client.connection.stream.write("+OK\r\n");
+    _ = try client.writer.interface.write("+OK\r\n");
     client.connection.stream.close();
 }
 

--- a/src/commands/string.zig
+++ b/src/commands/string.zig
@@ -23,7 +23,7 @@ pub fn set(client: *Client, args: []const Value) !void {
         try client.store.setString(key, value);
     }
 
-    _ = try client.connection.stream.write("+OK\r\n");
+    _ = try client.writer.interface.write("+OK\r\n");
 }
 
 pub fn get(client: *Client, args: []const Value) !void {

--- a/src/test_utils.zig
+++ b/src/test_utils.zig
@@ -57,7 +57,7 @@ pub const MockClient = struct {
     }
 
     pub fn writeBulkString(self: *MockClient, str: []const u8) !void {
-        try self.output.writer(self.allocator).print("${d}\r\n{s}\r\n", .{ str.len, str });
+        try self.output.print(self.allocator, "${d}\r\n{s}\r\n", .{ str.len, str });
     }
 
     pub fn writeNull(self: *MockClient) !void {
@@ -65,11 +65,11 @@ pub const MockClient = struct {
     }
 
     pub fn writeError(self: *MockClient, err_msg: []const u8) !void {
-        try self.output.writer(self.allocator).print("-{s}\r\n", .{err_msg});
+        try self.output.print(self.allocator, "-{s}\r\n", .{err_msg});
     }
 
     pub fn writeInt(self: *MockClient, num: anytype) !void {
-        try self.output.writer(self.allocator).print(":{d}\r\n", .{num});
+        try self.output.print(self.allocator, ":{d}\r\n", .{num});
     }
 
     pub fn getOutput(self: *MockClient) []const u8 {
@@ -183,13 +183,13 @@ pub const MockClient = struct {
 
     pub fn writeTupleAsArray(self: *MockClient, items: anytype) !void {
         const fields = std.meta.fields(@TypeOf(items));
-        try self.output.writer(self.allocator).print("*{d}\r\n", .{fields.len});
+        try self.output.print(self.allocator, "*{d}\r\n", .{fields.len});
 
         inline for (fields) |field| {
             const value = @field(items, field.name);
             switch (@TypeOf(value)) {
                 []const u8 => try self.writeBulkString(value),
-                i64, u64, u32, i32 => try self.output.writer(self.allocator).print(":{d}\r\n", .{value}),
+                i64, u64, u32, i32 => try self.output.print(self.allocator, ":{d}\r\n", .{value}),
                 else => {
                     // Handle string literals like *const [N:0]u8
                     const TypeInfo = @typeInfo(@TypeOf(value));


### PR DESCRIPTION
stores the File.Writer instead of the Io.Writer interface in the zdb.Writer struct, preventing undefined behaviour.

all calls to writer.x are now writer.interface.x.

fixes #1