### PR TITLE
fix rdb file reading issues

### DIFF
--- a/src/commands/registry.zig
+++ b/src/commands/registry.zig
@@ -60,7 +60,8 @@ pub const CommandRegistry = struct {
         // Skip auth check for commands that don't need it
         if (!std.mem.eql(u8, upper_name, "AUTH") and
             !std.mem.eql(u8, upper_name, "PING") and
-            !client.isAuthenticated()) {
+            !client.isAuthenticated())
+        {
             return client.writeError("NOAUTH Authentication required");
         }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -108,8 +108,7 @@ pub const Server = struct {
         // Load RDB file if it exists
         const file_exists = Reader.rdbFileExists();
         if (file_exists) {
-            const reader = try Reader.init(server.temp_arena.allocator(), @constCast(&server.store));
-            errdefer reader.deinit();
+            var reader = try Reader.init(server.temp_arena.allocator(), &server.store);
             defer reader.deinit();
 
             if (reader.readFile()) |data| {


### PR DESCRIPTION
making a copy of the reader in each function caused the seek-state to be reset on each call.
we now use the .reader field directly so state is preserved.

server.zig: redundant errdefer also removed as it did the same as defer.

registry.zig: zig fmt

fixes #6