### PR TITLE
feat: AOF reading and writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 zig-out/
 *.o
 *.rdb
+*.aof
 .vscode

--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,11 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
+    // For ZLS - builds but doesn't install anything
+    const check_exe = b.addExecutable(.{ .name = "check", .root_module = exe.root_module });
+    const check_step = b.step("check", "check for build errors");
+    check_step.dependOn(&check_exe.step);
+
     // Test steps - enhanced test runner system
     const unit_tests = b.addTest(.{
         .name = "test-unit",

--- a/src/aof/aof.zig
+++ b/src/aof/aof.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const Server = @import("../server.zig").Server;
+const Parser = @import("../parser.zig").Parser;
+const Command = @import("../parser.zig").Command;
+
+const DEFAULT_NAME = "test.aof";
+
+// TODO: AOF Rewrite
+// Get the state of the store at the time of rewrite, and create
+// the necessary commands to replicate it.
+
+pub const Writer = struct {
+    enabled: bool,
+    file_writer: ?std.fs.File.Writer,
+
+    // take path when ready to
+    pub fn init(enabled: bool) !Writer {
+        var fw: std.fs.File.Writer = undefined;
+        if (enabled) {
+            const file = try std.fs.cwd().openFile(DEFAULT_NAME, .{ .mode = .write_only });
+            fw = file.writer(&.{});
+            try fw.seekTo(try file.getEndPos());
+        }
+        return .{
+            .enabled = enabled,
+            .file_writer = if (enabled) fw else null,
+        };
+    }
+
+    pub fn deinit(self: *Writer) void {
+        if (self.file_writer) |fw| {
+            fw.file.close();
+        }
+    }
+
+    // only to be called if enabled
+    // could return an error too
+    // probably should
+    pub fn writer(self: *Writer) *std.Io.Writer {
+        return &self.file_writer.?.interface;
+    }
+};
+
+pub const Reader = struct {
+    file_reader: std.fs.File.Reader,
+    allocator: std.mem.Allocator,
+
+    // take path when ready to
+    pub fn init(allocator: std.mem.Allocator) !Reader {
+        const file = try std.fs.cwd().openFile(DEFAULT_NAME, .{ .mode = .read_only });
+        const reader = file.reader(&.{});
+        return .{
+            .file_reader = reader,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn read(self: *Reader, server: *Server) !void {
+        const allocator = server.temp_arena.allocator();
+        var parser = Parser.init(self.allocator);
+        // FIXME Maybe:  magic number as initial cap
+        var commands = try std.ArrayList(Command).initCapacity(allocator, 128);
+        defer commands.deinit(allocator);
+        const registry = &server.registry;
+
+        var writer = std.Io.Writer.Discarding.init(&.{});
+
+        while (parser.parse(&self.file_reader.interface)) |command| {
+            try commands.append(allocator, command);
+        } else |_| {}
+
+        const aof_bool = server.aof_writer.enabled;
+        server.aof_writer.enabled = false;
+        for (commands.items) |command| {
+            try registry.executeCommandAof(&writer.writer, &server.store, &server.aof_writer, command.args.items);
+        }
+        server.aof_writer.enabled = aof_bool;
+    }
+};

--- a/src/aof/aof.zig
+++ b/src/aof/aof.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const Server = @import("../server.zig").Server;
 const Parser = @import("../parser.zig").Parser;
 const Command = @import("../parser.zig").Command;
+const Registry = @import("../commands/registry.zig").CommandRegistry;
+const Client = @import("../client.zig").Client;
+const Store = @import("../store.zig").Store;
 
 const DEFAULT_NAME = "test.aof";
 
@@ -17,7 +20,8 @@ pub const Writer = struct {
     pub fn init(enabled: bool) !Writer {
         var fw: std.fs.File.Writer = undefined;
         if (enabled) {
-            const file = try std.fs.cwd().openFile(DEFAULT_NAME, .{ .mode = .write_only });
+            const file = std.fs.cwd().openFile(DEFAULT_NAME, .{ .mode = .write_only }) catch
+                try std.fs.cwd().createFile(DEFAULT_NAME, .{});
             fw = file.writer(&.{});
             try fw.seekTo(try file.getEndPos());
         }
@@ -34,8 +38,6 @@ pub const Writer = struct {
     }
 
     // only to be called if enabled
-    // could return an error too
-    // probably should
     pub fn writer(self: *Writer) *std.Io.Writer {
         return &self.file_writer.?.interface;
     }
@@ -44,36 +46,109 @@ pub const Writer = struct {
 pub const Reader = struct {
     file_reader: std.fs.File.Reader,
     allocator: std.mem.Allocator,
+    store: *Store,
+    registry: *Registry,
 
     // take path when ready to
-    pub fn init(allocator: std.mem.Allocator) !Reader {
+    pub fn init(allocator: std.mem.Allocator, store: *Store, registry: *Registry) !Reader {
         const file = try std.fs.cwd().openFile(DEFAULT_NAME, .{ .mode = .read_only });
         const reader = file.reader(&.{});
         return .{
             .file_reader = reader,
             .allocator = allocator,
+            .store = store,
+            .registry = registry,
         };
     }
 
-    pub fn read(self: *Reader, server: *Server) !void {
-        const allocator = server.temp_arena.allocator();
+    pub fn read(self: *Reader) !void {
         var parser = Parser.init(self.allocator);
-        // FIXME Maybe:  magic number as initial cap
-        var commands = try std.ArrayList(Command).initCapacity(allocator, 128);
-        defer commands.deinit(allocator);
-        const registry = &server.registry;
-
-        var writer = std.Io.Writer.Discarding.init(&.{});
+        var commands = try std.ArrayList(Command).initCapacity(self.allocator, 128);
+        defer commands.deinit(self.allocator);
 
         while (parser.parse(&self.file_reader.interface)) |command| {
-            try commands.append(allocator, command);
+            try commands.append(self.allocator, command);
         } else |_| {}
 
-        const aof_bool = server.aof_writer.enabled;
-        server.aof_writer.enabled = false;
         for (commands.items) |command| {
-            try registry.executeCommandAof(&writer.writer, &server.store, &server.aof_writer, command.args.items);
+            try self.registry.executeCommandAof(self.store, command.args.items);
         }
-        server.aof_writer.enabled = aof_bool;
+
+        for (commands.items) |*command| {
+            command.deinit();
+        }
+
+        self.file_reader.file.close();
     }
 };
+
+test "aof reading test" {
+    const testing = std.testing;
+    const reg_init = @import("../commands/init.zig");
+
+    // Read a command and test that the value is stored as expected
+    const test_file_data = "*3\r\n$3\r\nset\r\n$1\r\nt\r\n$4\r\ntest\r\n";
+    const test_file = try std.fs.cwd().createFile("aof_reading_test.aof", .{ .read = true });
+    defer std.fs.cwd().deleteFile("aof_reading_test.aof") catch {};
+    try test_file.writeAll(test_file_data);
+
+    var registry = try reg_init.initRegistry(std.testing.allocator);
+    defer registry.deinit();
+    var store: Store = .init(testing.allocator);
+    defer store.deinit();
+
+    var aof_reader: Reader = undefined;
+    aof_reader.allocator = testing.allocator;
+    aof_reader.file_reader = test_file.reader(&.{});
+    aof_reader.store = &store;
+    aof_reader.registry = &registry;
+
+    try aof_reader.read();
+
+    try testing.expect(std.mem.eql(u8, store.get("t").?.value.string, "test"));
+}
+test "aof writing test" {
+    const testing = std.testing;
+    const reg_init = @import("../commands/init.zig");
+
+    // Execute a command and test that it writes it correctly
+    const test_file_name = "aof_writing_test.aof";
+    const test_file = try std.fs.cwd().createFile(test_file_name, .{ .read = true });
+    defer std.fs.cwd().deleteFile("aof_writing_test.aof") catch {};
+
+    const test_file_data = "*3\r\n$3\r\nSET\r\n$1\r\nt\r\n$4\r\ntest\r\n";
+
+    var registry = try reg_init.initRegistry(std.testing.allocator);
+    var store: Store = .init(testing.allocator);
+    var parser = Parser.init(testing.allocator);
+    defer registry.deinit();
+    defer store.deinit();
+
+    var reader = std.Io.Reader.fixed(test_file_data);
+    var cmd = try parser.parse(&reader);
+    defer cmd.deinit();
+
+    const discarding = std.Io.Writer.Discarding.init(&.{});
+    var writer = discarding.writer;
+
+    var dummy_client: Client = undefined;
+    dummy_client.authenticated = true;
+
+    var aof_writer: Writer = undefined;
+    aof_writer.file_writer = test_file.writer(&.{});
+    aof_writer.enabled = true;
+
+    try registry.executeCommand(&writer, &dummy_client, &store, &aof_writer, cmd.args.items);
+
+    var file_reader = test_file.reader(&.{});
+
+    try testing.expect(std.mem.eql(u8, store.get("t").?.value.string, "test"));
+    const buf = try testing.allocator.alloc(u8, 1024);
+    defer testing.allocator.free(buf);
+    file_reader.interface.readSliceAll(buf) catch |e| {
+        if (e != error.EndOfStream) {
+            return e;
+        }
+    };
+    try testing.expect(std.mem.eql(u8, buf[0..test_file_data.len], test_file_data));
+}

--- a/src/client.zig
+++ b/src/client.zig
@@ -14,6 +14,7 @@ const CommandRegistry = @import("./commands/registry.zig").CommandRegistry;
 const Server = @import("./server.zig").Server;
 const PubSubContext = @import("./pubsub/pubsub.zig").PubSubContext;
 const ServerConfig = @import("./server_config.zig").ServerConfig;
+const resp = @import("./commands/resp.zig");
 
 var next_client_id: std.atomic.Value(u64) = std.atomic.Value(u64).init(1);
 
@@ -62,10 +63,14 @@ pub const Client = struct {
     }
 
     pub fn handle(self: *Client) !void {
+        var sr = self.connection.stream.reader(&.{});
+        const reader = sr.interface();
+        var sw = self.connection.stream.writer(&.{});
+        const writer = &sw.interface;
         while (true) {
             // Parse the incoming command from the client's stream.
-            var parser = Parser.init(self.allocator, self.connection.stream);
-            var command = parser.parse() catch |err| {
+            var parser = Parser.init(self.allocator);
+            var command = parser.parse(reader) catch |err| {
                 // If there's an error (like a closed connection), we stop handling this client.
                 if (err == error.EndOfStream) {
                     // In pubsub mode, we might want to keep the connection open even on EndOfStream
@@ -74,14 +79,15 @@ pub const Client = struct {
                     }
                     return;
                 }
+                // Socket error, the connection should be closed.
                 if (err == error.ReadFailed) {
                     if (self.is_in_pubsub_mode) {
                         std.log.debug("Client {} in pubsub mode, read failed", .{self.client_id});
                     }
-                    return err;
+                    return;
                 }
                 std.log.err("Parse error: {s}", .{@errorName(err)});
-                self.writeError("ERR protocol error", .{}) catch {};
+                resp.writeError(writer, "ERR protocol error") catch {};
                 continue;
             };
             defer command.deinit();
@@ -98,93 +104,10 @@ pub const Client = struct {
 
     // Dispatches the parsed command to the appropriate handler function.
     fn executeCommand(self: *Client, command: Command) !void {
-        try self.command_registry.executeCommand(self, command.args.items);
+        try self.command_registry.executeCommandClient(self, command.args.items);
     }
 
     pub fn isAuthenticated(self: *Client) bool {
-        return !self.server.config.requiresAuth() or self.authenticated;
-    }
-
-    // --- RESP Writing Helpers ---
-
-    pub fn writeError(self: *Client, comptime fmt: []const u8, args: anytype) !void {
-        const msg = try std.fmt.allocPrint(self.allocator, fmt, args);
-        defer self.allocator.free(msg);
-        const formatted = try std.fmt.allocPrint(self.allocator, "-{s}\r\n", .{msg});
-        defer self.allocator.free(formatted);
-        _ = try self.writer.interface.write(formatted);
-    }
-
-    pub fn writeBulkString(self: *Client, str: []const u8) !void {
-        const formatted = try std.fmt.allocPrint(self.allocator, "${d}\r\n{s}\r\n", .{ str.len, str });
-        defer self.allocator.free(formatted);
-        _ = try self.writer.interface.write(formatted);
-    }
-
-    pub fn writeIntAsString(self: *Client, i: i64) !void {
-        var buf: [8]u8 = undefined;
-        const int_str = try std.fmt.bufPrint(&buf, "{}", .{i});
-        try self.writeBulkString(int_str);
-    }
-
-    pub fn writeInt(self: *Client, value: i64) !void {
-        const formatted = try std.fmt.allocPrint(self.allocator, ":{d}\r\n", .{value});
-        defer self.allocator.free(formatted);
-        _ = try self.writer.interface.write(formatted);
-    }
-
-    pub fn writeListLen(self: *Client, count: usize) !void {
-        try self.writer.interface.print("*{d}\r\n", .{count});
-    }
-
-    pub fn writeTupleAsArray(self: *Client, items: anytype) !void {
-        const T = @TypeOf(items);
-        const info = @typeInfo(T);
-
-        // 2. At compile time, verify the input is a tuple.
-        //    A tuple in Zig is an anonymous struct.
-        comptime {
-            switch (info) {
-                .@"struct" => |struct_info| {
-                    if (!struct_info.is_tuple) {
-                        @compileError("This function only accepts a tuple. Received: " ++ @typeName(T));
-                    }
-                },
-                else => @compileError("This function only accepts a tuple. Received: " ++ @typeName(T)),
-            }
-        }
-
-        const struct_info = info.@"struct";
-
-        const formatted = try std.fmt.allocPrint(self.allocator, "*{d}\r\n", .{struct_info.fields.len});
-        _ = try self.writer.interface.write(formatted);
-
-        // 4. Use 'inline for' to iterate over the tuple's elements at compile time.
-        //    This loop is "unrolled" by the compiler, generating specific code
-        //    for each element's type with no runtime overhead.
-        inline for (items) |item| {
-            // Check the type of the current item and call the correct serializer.
-            const ItemType = @TypeOf(item);
-            if (ItemType == []const u8) {
-                try self.writeBulkString(item);
-            } else if (ItemType == i64) {
-                try self.writeInt(item);
-            } else {
-                // Handle string literals and other pointer-to-array types by checking if they can be coerced to []const u8
-                const item_as_slice: []const u8 = item;
-                try self.writeBulkString(item_as_slice);
-            }
-        }
-    }
-
-    pub fn writeNull(self: *Client) !void {
-        _ = try self.writer.interface.write("$-1\r\n");
-    }
-
-    pub fn writePrimitiveValue(self: *Client, value: PrimitiveValue) !void {
-        switch (value) {
-            .string => |str| try self.writeBulkString(str),
-            .int => |i| try self.writeInt(i),
-        }
+        return self.authenticated or !self.server.config.requiresAuth();
     }
 };

--- a/src/commands/init.zig
+++ b/src/commands/init.zig
@@ -12,180 +12,220 @@ pub fn initRegistry(allocator: Allocator) !CommandRegistry {
 
     try registry.register(.{
         .name = "PING",
-        .handler = connection_commands.ping,
+        .handler = .{ .default = connection_commands.ping },
         .min_args = 1,
         .max_args = 2,
         .description = "Ping the server",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "ECHO",
-        .handler = connection_commands.echo,
+        .handler = .{ .default = connection_commands.echo },
         .min_args = 2,
         .max_args = 2,
         .description = "Echo the given string",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "QUIT",
-        .handler = connection_commands.quit,
+        .handler = .{ .client_handler = connection_commands.quit },
         .min_args = 1,
         .max_args = 1,
         .description = "Close the connection",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "SET",
-        .handler = string.set,
+        .handler = .{ .store_handler = string.set },
         .min_args = 3,
         .max_args = 3,
         .description = "Set string value of a key",
+        .write_to_aof = true,
     });
 
     try registry.register(.{
         .name = "GET",
-        .handler = string.get,
+        .handler = .{ .store_handler = string.get },
         .min_args = 2,
         .max_args = 2,
         .description = "Get string value of a key",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "INCR",
-        .handler = string.incr,
+        .handler = .{ .store_handler = string.incr },
         .min_args = 2,
         .max_args = 2,
         .description = "Increment the value of a key",
+        .write_to_aof = true,
     });
 
     try registry.register(.{
         .name = "DECR",
-        .handler = string.decr,
+        .handler = .{ .store_handler = string.decr },
         .min_args = 2,
         .max_args = 2,
         .description = "Decrement the value of a key",
+        .write_to_aof = true,
     });
 
     try registry.register(.{
         .name = "HELP",
-        .handler = connection_commands.help,
+        .handler = .{ .default = connection_commands.help },
         .min_args = 1,
         .max_args = 1,
         .description = "Show help message",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "DEL",
-        .handler = string.del,
+        .handler = .{ .store_handler = string.del },
         .min_args = 2,
         .max_args = null,
         .description = "Delete key",
+        .write_to_aof = true,
     });
 
     try registry.register(.{
         .name = "SAVE",
-        .handler = rdb.save,
+        .handler = .{ .client_handler = rdb.save },
         .min_args = 1,
         .max_args = 1,
         .description = "The SAVE commands performs a synchronous save of the dataset producing a point in time snapshot of all the data inside the Redis instance, in the form of an RDB file.",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "PUBLISH",
-        .handler = pubsub.publish,
+        .handler = .{ .client_handler = pubsub.publish },
         .min_args = 3,
         .max_args = 3,
         .description = "Publish message",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "SUBSCRIBE",
-        .handler = pubsub.subscribe,
+        .handler = .{ .client_handler = pubsub.subscribe },
         .min_args = 2,
         .max_args = null,
         .description = "Subscribe to channels",
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "EXPIRE",
-        .handler = string.expire,
+        .handler = .{ .store_handler = string.expire },
         .min_args = 3,
         .max_args = null,
         .description = "Expire key",
+        // TODO: convert to expireat
+        .write_to_aof = false,
+    });
+
+    try registry.register(.{
+        .name = "EXPIREAT",
+        .handler = .{ .store_handler = string.expireAt },
+        .min_args = 3,
+        .max_args = null,
+        .description = "Expire key",
+        .write_to_aof = true,
     });
 
     try registry.register(.{
         .name = "AUTH",
-        .handler = connection_commands.auth,
+        .handler = .{ .client_handler = connection_commands.auth },
         .min_args = 2,
         .max_args = 2,
         .description = "Authenticate to the server",
+        .write_to_aof = false,
     });
 
     // List commands: LPUSH, RPUSH, LPOP, RPOP, LLEN, LRANGE
 
     try registry.register(.{
         .name = "LPUSH",
-        .handler = list.lpush,
+        .handler = .{ .store_handler = list.lpush },
         .min_args = 3,
         .max_args = null,
         .description = "Prepend one or multiple values to a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "RPUSH",
-        .handler = list.rpush,
+        .handler = .{ .store_handler = list.rpush },
         .min_args = 3,
         .max_args = null,
         .description = "Append one or multiple values to a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "LPOP",
-        .handler = list.lpop,
+        .handler = .{ .store_handler = list.lpop },
         .min_args = 2,
         .max_args = 3,
         .description = "Remove and return the first element of a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "RPOP",
-        .handler = list.rpop,
+        .handler = .{ .store_handler = list.rpop },
         .min_args = 2,
         .max_args = 3,
         .description = "Remove and return the last element of a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "LLEN",
-        .handler = list.llen,
+        .handler = .{ .store_handler = list.llen },
         .min_args = 2,
         .max_args = 2,
         .description = "Get the length of a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "LINDEX",
-        .handler = list.lindex,
+        .handler = .{ .store_handler = list.lindex },
         .min_args = 3,
         .max_args = 3,
         .description = "Get an element from a list by its index",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "LSET",
-        .handler = list.lset,
+        .handler = .{ .store_handler = list.lset },
         .min_args = 4,
         .max_args = 4,
         .description = "Set the value of an element in a list by its index",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     try registry.register(.{
         .name = "LRANGE",
-        .handler = list.lrange,
+        .handler = .{ .store_handler = list.lrange },
         .min_args = 4,
         .max_args = 4,
         .description = "Get a range of elements from a list",
+        // TODO: test
+        .write_to_aof = false,
     });
 
     return registry;

--- a/src/commands/list.zig
+++ b/src/commands/list.zig
@@ -3,35 +3,37 @@ const Client = @import("../client.zig").Client;
 const Value = @import("../parser.zig").Value;
 const PrimitiveValue = @import("../store.zig").PrimitiveValue;
 const ZedisListNode = @import("../store.zig").ZedisListNode;
+const Store = @import("../store.zig").Store;
+const resp = @import("./resp.zig");
 
-pub fn lpush(client: *Client, args: []const Value) !void {
+pub fn lpush(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
 
-    const list = try client.store.getSetList(key);
+    const list = try store.getSetList(key);
 
     for (args[2..]) |arg| {
         try list.prepend(.{ .string = arg.asSlice() });
     }
 
-    try client.writeInt(@intCast(list.len()));
+    try resp.writeInt(writer, @intCast(list.len()));
 }
 
-pub fn rpush(client: *Client, args: []const Value) !void {
+pub fn rpush(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
 
-    const list = try client.store.getSetList(key);
+    const list = try store.getSetList(key);
 
     for (args[2..]) |arg| {
         try list.append(.{ .string = arg.asSlice() });
     }
 
-    try client.writeInt(@intCast(list.len()));
+    try resp.writeInt(writer, @intCast(list.len()));
 }
 
-pub fn lpop(client: *Client, args: []const Value) !void {
+pub fn lpop(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
-    const list = try client.store.getList(key) orelse {
-        try client.writeNull();
+    const list = try store.getList(key) orelse {
+        try resp.writeNull(writer);
         return;
     };
 
@@ -45,29 +47,29 @@ pub fn lpop(client: *Client, args: []const Value) !void {
     const actual_count = @min(count, list_len);
 
     if (actual_count == 0) {
-        try client.writeNull();
+        try resp.writeNull(writer);
         return;
     }
 
     if (actual_count == 1) {
         const item = list.popFirst().?;
-        try client.writePrimitiveValue(item);
+        try resp.writePrimitiveValue(writer, item);
         return;
     }
     if (actual_count > 1) {
-        try client.writeListLen(actual_count);
+        try resp.writeListLen(writer, actual_count);
         for (0..actual_count) |_| {
             const item = list.popFirst().?;
-            try client.writePrimitiveValue(item);
+            try resp.writePrimitiveValue(writer, item);
         }
         return;
     }
 }
 
-pub fn rpop(client: *Client, args: []const Value) !void {
+pub fn rpop(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
-    const list = try client.store.getList(key) orelse {
-        try client.writeNull();
+    const list = try store.getList(key) orelse {
+        try resp.writeNull(writer);
         return;
     };
 
@@ -81,79 +83,79 @@ pub fn rpop(client: *Client, args: []const Value) !void {
     const actual_count = @min(count, list_len);
 
     if (actual_count == 0) {
-        try client.writeNull();
+        try resp.writeNull(writer);
         return;
     }
 
     if (actual_count == 1) {
         const item = list.pop().?;
-        try client.writePrimitiveValue(item);
+        try resp.writePrimitiveValue(writer, item);
         return;
     }
     if (actual_count > 1) {
-        try client.writeListLen(actual_count);
+        try resp.writeListLen(writer, actual_count);
         for (0..actual_count) |_| {
             const item = list.pop().?;
-            try client.writePrimitiveValue(item);
+            try resp.writePrimitiveValue(writer, item);
         }
         return;
     }
 }
 
-pub fn llen(client: *Client, args: []const Value) !void {
+pub fn llen(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
-    const list = try client.store.getList(key);
+    const list = try store.getList(key);
 
     if (list) |l| {
-        try client.writeInt(@intCast(l.len()));
+        try resp.writeInt(writer, @intCast(l.len()));
     } else {
-        try client.writeInt(0);
+        try resp.writeInt(writer, 0);
     }
 }
 
-pub fn lindex(client: *Client, args: []const Value) !void {
+pub fn lindex(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
     const index = try args[2].asInt();
-    const list = try client.store.getList(key) orelse {
-        try client.writeNull();
+    const list = try store.getList(key) orelse {
+        try resp.writeNull(writer);
         return;
     };
 
     const item = list.getByIndex(index) orelse {
-        try client.writeNull();
+        try resp.writeNull(writer);
         return;
     };
 
-    try client.writePrimitiveValue(item);
+    try resp.writePrimitiveValue(writer, item);
 }
 
-pub fn lset(client: *Client, args: []const Value) !void {
+pub fn lset(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
     const index = try args[2].asInt();
     const value = args[3].asSlice();
 
-    const list = try client.store.getList(key) orelse {
-        return client.writeError("ERR no such key", .{});
+    const list = try store.getList(key) orelse {
+        return resp.writeError(writer, "ERR no such key");
     };
 
     try list.setByIndex(index, .{ .string = value });
 
-    try client.writeBulkString("OK");
+    try resp.writeBulkString(writer, "OK");
 }
 
-pub fn lrange(client: *Client, args: []const Value) !void {
+pub fn lrange(writer: *std.Io.Writer, store: *Store, args: []const Value) !void {
     const key = args[1].asSlice();
     const start = try args[2].asInt();
     const stop = try args[3].asInt();
 
-    const list = try client.store.getList(key) orelse {
-        try client.writeListLen(0);
+    const list = try store.getList(key) orelse {
+        try resp.writeListLen(writer, 0);
         return;
     };
 
     const list_len = list.len();
     if (list_len == 0) {
-        try client.writeListLen(0);
+        try resp.writeListLen(writer, 0);
         return;
     }
 
@@ -167,7 +169,7 @@ pub fn lrange(client: *Client, args: []const Value) !void {
     } else blk: {
         const pos_index = @as(usize, @intCast(start));
         if (pos_index >= list_len) {
-            try client.writeListLen(0);
+            try resp.writeListLen(writer, 0);
             return;
         }
         break :blk pos_index;
@@ -189,12 +191,12 @@ pub fn lrange(client: *Client, args: []const Value) !void {
 
     // Handle invalid range
     if (actual_start > actual_stop) {
-        try client.writeListLen(0);
+        try resp.writeListLen(writer, 0);
         return;
     }
 
     const count = actual_stop - actual_start + 1;
-    try client.writeListLen(count);
+    try resp.writeListLen(writer, count);
 
     // Stream items directly without intermediate allocation
     var current = list.list.first;
@@ -202,7 +204,7 @@ pub fn lrange(client: *Client, args: []const Value) !void {
     while (current) |node| : (i += 1) {
         if (i >= actual_start and i <= actual_stop) {
             const list_node: *ZedisListNode = @fieldParentPtr("node", node);
-            try client.writePrimitiveValue(list_node.data);
+            try resp.writePrimitiveValue(writer, list_node.data);
         }
         if (i > actual_stop) break;
         current = node.next;

--- a/src/commands/rdb.zig
+++ b/src/commands/rdb.zig
@@ -5,13 +5,16 @@ const ZedisObject = store.ZedisObject;
 const Client = @import("../client.zig").Client;
 const Value = @import("../parser.zig").Value;
 const ZDB = @import("../rdb/zdb.zig");
+const resp = @import("./resp.zig");
 
 pub fn save(client: *Client, args: []const Value) !void {
     _ = args;
+    var sw = client.connection.stream.writer(&.{});
+    const writer = &sw.interface;
 
     var zdb = try ZDB.Writer.init(client.allocator, client.store, "test.rdb");
     defer zdb.deinit();
     try zdb.writeFile();
 
-    try client.writeBulkString("OK");
+    try resp.writeBulkString(writer, "OK");
 }

--- a/src/commands/registry.zig
+++ b/src/commands/registry.zig
@@ -70,16 +70,17 @@ pub const CommandRegistry = struct {
 
     pub fn executeCommandAof(
         self: *CommandRegistry,
-        writer: *std.Io.Writer,
         store: *Store,
-        aof_writer: *aof.Writer,
         args: []const Value,
     ) !void {
         var dummy_client: Client = undefined;
+        dummy_client.authenticated = true;
+        const discarding = std.Io.Writer.Discarding.init(&.{});
+        var writer = discarding.writer;
+        var aof_writer: aof.Writer = try .init(false);
         // We should only be calling this command from the aof, so auth is assumed.
         // We should not be calling commands that require a real client.
-        dummy_client.authenticated = true;
-        try self.executeCommand(writer, &dummy_client, store, aof_writer, args);
+        try self.executeCommand(&writer, &dummy_client, store, &aof_writer, args);
     }
 
     pub fn executeCommand(

--- a/src/commands/resp.zig
+++ b/src/commands/resp.zig
@@ -1,0 +1,86 @@
+const std = @import("std");
+const storeModule = @import("../store.zig");
+const Store = storeModule.Store;
+const ZedisObject = storeModule.ZedisObject;
+const Client = @import("../client.zig").Client;
+const Value = @import("../parser.zig").Value;
+const ZedisValue = storeModule.ZedisValue;
+const PrimitiveValue = storeModule.PrimitiveValue;
+
+// --- RESP Writing Helpers ---
+
+pub fn writeError(writer: *std.Io.Writer, msg: []const u8) !void {
+    try writer.print("-{s}\r\n", .{msg});
+}
+
+pub fn writeBulkString(writer: *std.Io.Writer, str: []const u8) !void {
+    try writer.print("${d}\r\n{s}\r\n", .{ str.len, str });
+}
+
+pub fn writeIntBulkString(writer: *std.Io.Writer, value: i64) !void {
+    var buf: [19]u8 = undefined;
+    const len = std.fmt.printInt(&buf, value, 10, .upper, .{});
+    try writer.print("${d}\r\n{s}\r\n", .{ len, buf[0..len] });
+}
+
+pub fn writeSingleIntBulkString(writer: *std.Io.Writer, value: i64) !void {
+    try writer.print("${d}\r\n{d}\r\n", .{ 1, value });
+}
+
+pub fn writeInt(writer: *std.Io.Writer, value: i64) !void {
+    try writer.print(":{d}\r\n", .{value});
+}
+
+pub fn writeListLen(writer: *std.Io.Writer, count: usize) !void {
+    try writer.print("*{d}\r\n", .{count});
+}
+
+pub fn writeTupleAsArray(writer: *std.Io.Writer, items: anytype) !void {
+    const T = @TypeOf(items);
+    const info = @typeInfo(T);
+
+    // 2. At compile time, verify the input is a tuple.
+    //    A tuple in Zig is an anonymous struct.
+    comptime {
+        switch (info) {
+            .@"struct" => |struct_info| {
+                if (!struct_info.is_tuple) {
+                    @compileError("This function only accepts a tuple. Received: " ++ @typeName(T));
+                }
+            },
+            else => @compileError("This function only accepts a tuple. Received: " ++ @typeName(T)),
+        }
+    }
+
+    const struct_info = info.@"struct";
+
+    try writer.print("*{d}\r\n", .{struct_info.fields.len});
+
+    // 4. Use 'inline for' to iterate over the tuple's elements at compile time.
+    //    This loop is "unrolled" by the compiler, generating specific code
+    //    for each element's type with no runtime overhead.
+    inline for (items) |item| {
+        // Check the type of the current item and call the correct serializer.
+        const ItemType = @TypeOf(item);
+        if (ItemType == []const u8) {
+            try writeBulkString(writer, item);
+        } else if (ItemType == i64) {
+            try writeInt(writer, item);
+        } else {
+            // Handle string literals and other pointer-to-array types by checking if they can be coerced to []const u8
+            const item_as_slice: []const u8 = item;
+            try writeBulkString(writer, item_as_slice);
+        }
+    }
+}
+
+pub fn writeNull(writer: *std.Io.Writer) !void {
+    _ = try writer.write("$-1\r\n");
+}
+
+pub fn writePrimitiveValue(writer: *std.Io.Writer, value: PrimitiveValue) !void {
+    switch (value) {
+        .string => |str| try writeBulkString(writer, str),
+        .int => |i| try writeInt(writer, i),
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,7 +11,7 @@ pub fn main() !void {
 
     // Create and start the server.
     var redis_server = server.Server.init(allocator, host, port) catch |err| {
-        std.log.err("Error server init: {any}", .{@errorName(err)});
+        std.log.err("Error server init: {s}", .{@errorName(err)});
         return;
     };
     defer redis_server.deinit();

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -30,6 +30,9 @@ pub const Command = struct {
     }
 
     pub fn deinit(self: *Command) void {
+        for (self.args.items) |arg| {
+            self.allocator.free(arg.data);
+        }
         self.args.deinit(self.allocator);
     }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -112,11 +112,16 @@ pub const Server = struct {
 
         // Prefer AOF to RDB
         // Load AOF file if it exists
-        if (server.aof_writer.enabled) {
+        // 'true' to be replaced with user option (use aof/rdb on boot)
+        if (true) {
             std.log.info("Loading AOF", .{});
-            var aof_reader = try aof.Reader.init(server.temp_arena.allocator());
-            aof_reader.read(&server) catch |err| {
+            var aof_reader = aof.Reader.init(server.temp_arena.allocator(), &server.store, &server.registry) catch |err| {
                 std.log.err("Failed to load AOF: {s}", .{@errorName(err)});
+                return err;
+            };
+            aof_reader.read() catch |err| {
+                std.log.err("Failed to load AOF: {s}", .{@errorName(err)});
+                return err;
             };
         } else {
             // Load RDB file if it exists

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -18,6 +18,9 @@ comptime {
     _ = @import("rdb/checksum.zig");
     _ = @import("rdb/zdb.zig");
 
+    // AOF tests
+    _ = @import("aof/aof.zig");
+
     // Test utilities
     _ = @import("test_utils.zig");
 


### PR DESCRIPTION
adds the AOF reader and writer which allows AOF logging and execution on startup.
with this, many of the details in the commands are decoupled from the client and network streams, instead working with readers and writers as interfaces.

this makes things more usable throughout the codebase and makes it easier to develop around.
some allocations have also been reduced (around resp responses), and a memory leak in the parser fixed.

quite a big one, so of course review and any changes encouraged.